### PR TITLE
Update phive

### DIFF
--- a/docker/application/Dockerfile
+++ b/docker/application/Dockerfile
@@ -1,15 +1,8 @@
 FROM webdevops/php-dev:8.1
 
 COPY --from=composer:2 /usr/bin/composer /usr/local/bin/composer
+COPY --from=phario/phive:0.15.2 /usr/local/bin/phive /usr/local/bin/phive
 
-RUN wget -O phive.phar "https://phar.io/releases/phive.phar" && \
-    wget -O phive.phar.asc "https://phar.io/releases/phive.phar.asc" && \
-    gpg --keyserver hkps://keys.openpgp.org --recv-keys 0x6AF725270AB81E04D79442549D8A98B29B2D5D79 && \
-    gpg --verify phive.phar.asc phive.phar && \
-    rm phive.phar.asc && \
-    chmod +x phive.phar && \
-    mv phive.phar /usr/local/bin/phive && \
-    mkdir "/home/$APPLICATION_USER/.phive"
 
 # configure services
 RUN set -x \


### PR DESCRIPTION
Get phive from official docker image instead of manuall install. Should be faster since docker image can be cached seperately